### PR TITLE
Refactor script to allow for remembering alerts for less spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 ## Table of contents
 
+  * [Updates](#updates)
   * [Introduction](#introduction)
   * [Installation](#installation)
   * [Configuration](#configuration)
   * [Examples](#examples)
   * [Notes](#notes)
 
+## Updates
+
+  * 12/10/2020
+  ** The configuration file JSON schema changed to enable new functionality.
+  ** The script now supports a default rule that applies to all quotas. There is no need to define a rule for every quota.
+  ** Multiple rules can now be specified per each of the checks, including default quota rules.
+  ** Script now stores the alert history in a file to prevent alerting multiple times for the same condition.
+  ** Script was updated to only alert if an condition is new or crosses a higher alerting threshold.
 
 ## Introduction
 This script generates email alerts for a Qumulo cluster using the REST API. The Qumulo API tools are required to make the script work and and they are available for download from your Qumulo cluster. For more information, please check out the [Qumulo GitHub](https://qumulo.github.io/) page for more information on the API. The script is aimed to be customized to the user's desire using 'alert rules' or a list of several JSON schemas; each with its own configuration. Currently, the script generates three different types of alerts:
@@ -16,9 +25,14 @@ This script generates email alerts for a Qumulo cluster using the REST API. The 
   * Directory Quotas by Threshold
   * Replication Relationships by Error (Both Source & Target)
 
-If any of the alert conditions are triggered, a single email will be sent to all of the configured recipients. Any alert can also include a custom message by filling in the `custom_msg` field for each 'rule'.
+If any of the alert conditions are triggered, a single email will be sent to all of the configured recipients. Any alert can also include a custom message by filling in the `custom_msg` field for each 'rule'. A summary of the expected behavior of this script is:
 
-The alert conditions are checked a single time when the script is run. The suggested method to run this script is via a `cron` job which periodically executes the script. For more information regarding `cron` please check out [Ubuntu's Cron How To](https://help.ubuntu.com/community/CronHowto).
+  * The alert conditions are checked a single time when the script is run.
+  * Any rules or alerts that are triggered are stored in a local file `history.json`.
+  * If the current alert condition matches an entry in the `history.json` file, then nothing is done.
+  * If the current alert condition matches and exceeds what is in the `history.json` file, then a new alert is sent.
+
+The suggested method to run this script is via a `cron` job which periodically executes the script. For more information regarding `cron` please check out [Ubuntu's Cron How To](https://help.ubuntu.com/community/CronHowto).
 
 Lastly, all email alerts include a time stamp indicating when the alert was sent.
 
@@ -45,7 +59,7 @@ At this point, it is expected that you have a Qumulo cluster with the API Tools 
   1. Use `example_config.json` as a guide to creating a `config.json` with your alerting rules. The fields for this file are described after this section.
   2. Set up a `cron` job to run as often as you like to check for alerts. See [CronHowto](https://help.ubuntu.com/community/CronHowto) if you have any questions. Example command `./cluster_email_alerts.py --config /root/config.json`
 
-The `config.json` file contains 5 schemas and each can have multiple objects. These objects are what we call a `rule` and are individually interpreted by the script. The schemas are:
+The `config.json` file contains 6 stanzas and each can have multiple objects. These stanzas are groups objects of `rules` and are individually interpreted by the script. The stanzas are:
 
   1. Email Settings
      - `server_address` - The email server or relay that will route the emails sent by the script.
@@ -58,13 +72,24 @@ The `config.json` file contains 5 schemas and each can have multiple objects. Th
      - `password` - The password to access the REST API.
      - `rest_port` - The TCP port on which to access the REST API. Default of 8000.
 
-  3. Quota Rules - This rule triggers when a directory quota exceeds a used percentage threshold. The fields are:
-     - `name` - A friendly name for the quota alert as some paths can be very long or descriptive enough.
-     - `path` - The path on which a directory quota exists. This path will be looked up using the API to get the current usage.
-     - `thresholds` - A list of integers that describe the thresholds at which to send an alert. If exceeded, the script will only send the highest exceeded threshold for each rule.
-     - `mail_to` - A list of email addresses to send an alert to; only for this specific rule.
-     - `include_capacity` - A boolean that allows you to include or exclude including the current total capacity of the cluster.
-     - `custom_msg` - A field that will be included with each quota rule to provide instructions or guidance to the email recipients. If blank, it will not be included.
+  3. Quota Rules - These rule triggers when a directory quota exceeds a used percentage threshold. The fields are:
+     - `quota_rules` - The top level stanza containing all DEFINED quota rules.
+       - `path` - The path on which a directory quota exists. This path will be looked up using the API to get the current usage.
+         - `rules` - The collection of rules for this particular path.
+           - `$RULE_NAME` - The friendly name of the rule. There can be multiple of these stanzas; one for each rule for this specific path.
+             - `thresholds` - A list of integers that describe the thresholds at which to send an alert. If exceeded, the script will only send the highest exceeded threshold for each rule.
+             - `mail_to` - A list of email addresses to send an alert to; only for this specific rule.
+             - `include_capacity` - A boolean that allows you to include or exclude including the current total capacity of the cluster.
+             - `custom_msg` - A field that will be included with each quota rule to provide instructions or guidance to the email recipients. If blank, it will not be included.
+
+  4. Default Quota Rules - These rules trigger for all directory quotas that do NOT have a defined rule, in the `quota_rules` stanza.
+     - `default_quota_rules` - The top level stanza containing all NON-DEFINED quota rules.
+       - `rules` - The collection of rules for the default or non-defined quotas.
+         - `$RULE_NAME` - The friendly name of the rule. There can be multiple of these stanzas; one per rule.
+           - `thresholds` - A list of integers that describe the thresholds at which to send an alert. If exceeded, the script will only send the highest exceeded threshold for each rule.
+           - `mail_to` - A list of email addresses to send an alert to; only for this specific rule.
+           - `include_capacity` - A boolean that allows you to include or exclude including the current total capacity of the cluster.
+           - `custom_msg` - A field that will be included with each quota rule to provide instructions or guidance to the email recipients. If blank, it will not be included.
 
   4. Capacity Rules - This rule will trigger if the cluster exceeds a certain used percentage threshold. The fields are:
      - `thresholds` - Same as the quota, what thresholds to alert on. Only the highest matching threshold will be alerted on.
@@ -103,7 +128,9 @@ and write access to the user regardless of file system permissions.
      - Add multiple quota rules. Each one will be triggered individually.
   2. Will multiple emails be sent if a quota exceeds them?
      - No, a single email will be sent for the highest exceeded threshold.
-  3. How do I send different `custom_msg` depending on the threshold?
+  3. Will the same alert be sent if the quota has already exceeded a threshold?
+     - No, the alert state will be remembered in the `history.json` file. A new alert will only be sent if the next threshold is exceeded or if the alert condition is cleared and it re-alerts.
+  4. How do I send different `custom_msg` depending on the threshold?
      - Create multiple rules, with a different `custom_msg` each. Note that this can result in sending two emails, one for each rule.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -12,14 +12,18 @@
 ## Updates
 
   * 12/10/2020
-  ** The configuration file JSON schema changed to enable new functionality.
-  ** The script now supports a default rule that applies to all quotas. There is no need to define a rule for every quota.
-  ** Multiple rules can now be specified per each of the checks, including default quota rules.
-  ** Script now stores the alert history in a file to prevent alerting multiple times for the same condition.
-  ** Script was updated to only alert if an condition is new or crosses a higher alerting threshold.
+    * The configuration file JSON schema changed to enable new functionality.
+    * The script now supports a default rule that applies to all quotas. There is no need to define a rule for every quota.
+    * Multiple rules can now be specified per each of the checks, including default quota rules.
+    * Script now stores the alert history in a file to prevent alerting multiple times for the same condition.
+    * Script was updated to only alert if an condition is new or crosses a higher alerting threshold.
 
 ## Introduction
-This script generates email alerts for a Qumulo cluster using the REST API. The Qumulo API tools are required to make the script work and and they are available for download from your Qumulo cluster. For more information, please check out the [Qumulo GitHub](https://qumulo.github.io/) page for more information on the API. The script is aimed to be customized to the user's desire using 'alert rules' or a list of several JSON schemas; each with its own configuration. Currently, the script generates three different types of alerts:
+This script generates email alerts for a Qumulo cluster using the REST API. 
+
+The Qumulo API tools are required to make the script work and and they are available for download from your Qumulo cluster. For more information, please check out the [Qumulo GitHub](https://qumulo.github.io/) page for more information on the API. T
+
+he script is aimed to be customized to the user's desire using 'alert rules' or a list of several JSON schemas; each with its own configuration. Currently, the script generates three different types of alerts:
 
   * Cluster Capacity by Threshold
   * Directory Quotas by Threshold
@@ -31,6 +35,7 @@ If any of the alert conditions are triggered, a single email will be sent to all
   * Any rules or alerts that are triggered are stored in a local file `history.json`.
   * If the current alert condition matches an entry in the `history.json` file, then nothing is done.
   * If the current alert condition matches and exceeds what is in the `history.json` file, then a new alert is sent.
+  * If the current rule condition does not match any alert, it is removed from the `history.json` file.
 
 The suggested method to run this script is via a `cron` job which periodically executes the script. For more information regarding `cron` please check out [Ubuntu's Cron How To](https://help.ubuntu.com/community/CronHowto).
 

--- a/cluster_email_alerts.py
+++ b/cluster_email_alerts.py
@@ -20,12 +20,15 @@ be configured are:
     - Quota Capacity Exceeded (Soft Quota Alert)
     - Cluster Capacity Exceeded
     - Replication Relationship Errors
+
+The alerts will be sent if they are new, and will not re-alert on the same
+condition if the script is run again. However, if the rule being checked exceeds
+a new threshold, it will alert on the new higher threshold.
 """
 
 # Import Python Libraries
 import argparse
 import datetime
-import functools
 import json
 import logging
 import os
@@ -33,7 +36,7 @@ import smtplib
 import sys
 from collections import namedtuple
 from email.mime.text import MIMEText
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict, List, Sequence, Tuple
 
 # Import Qumulo REST Libraries
 import qumulo.lib.auth
@@ -41,9 +44,14 @@ import qumulo.lib.opts
 import qumulo.lib.request
 import qumulo.rest
 
+#   ____ _     ___  ____    _    _     ____
+#  / ___| |   / _ \| __ )  / \  | |   / ___|
+# | |  _| |  | | | |  _ \ / _ \ | |   \___ \
+# | |_| | |__| |_| | |_) / ___ \| |___ ___) |
+#  \____|_____\___/|____/_/   \_\_____|____/
+
 log = logging.getLogger(__name__)
 
-# Size Definitions in Kilobytes - base10
 KILOBYTE = 1000
 MEGABYTE = 1000 * KILOBYTE
 GIGABYTE = 1000 * MEGABYTE
@@ -56,38 +64,93 @@ EmailSettings = namedtuple(
 RestInfo = namedtuple('RestInfo', ['conninfo', 'creds'])
 
 
-def load_config(config: str) -> Dict[str, Any]:
+#  _   _ _____ _     ____  _____ ____  ____
+# | | | | ____| |   |  _ \| ____|  _ \/ ___|
+# | |_| |  _| | |   | |_) |  _| | |_) \___ \
+# |  _  | |___| |___|  __/| |___|  _ < ___) |
+# |_| |_|_____|_____|_|   |_____|_| \_\____/
+
+
+def load_json(file: str) -> Dict[str, Any]:
+    """Load a file and ensure that it's valid JSON."""
+    try:
+        file_fh = open(file, 'r')
+        data = json.load(file_fh)
+        return data
+    except ValueError as error:
+        sys.exit(f'Invalid JSON file: {file}. Error: {error}')
+    finally:
+        file_fh.close()
+
+
+def humanize_bytes(num: float, suffix: str = 'B') -> str:
     """
-    Load the configuration and ensure that it's valid JSON.
+    Convert bytes to a more human friendly size in base 10 to match the WebUI.
     """
-    if os.path.exists(config):
-        config_fh = open(config, 'r')
-        try:
-            data = json.load(config_fh)
-            return data
-        except ValueError as error:
-            sys.exit('Invalid JSON file: {}. Error: {}'.format(config, error))
-        finally:
-            config_fh.close()
-    else:
-        sys.exit('File {} does not exist'.format(config))
+    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+        if abs(num) < 1000.0:
+            return '%3.1f%s%s' % (num, unit, suffix)
+        num /= 1000.0
+    return '%.1f%s%s' % (num, 'Y', suffix)
 
 
 def cluster_login(username: str, password: str, cluster: str, port: int) -> RestInfo:
-    """
-    Generate the credentials object used to query Qumulo's API.
-    """
+    """Generate the credentials object used to query Qumulo's API."""
     # Open a connection to the REST server on the cluster.
     conninfo = qumulo.lib.request.Connection(cluster, int(port))
 
-    # Get the bearer token by passing through 'conninfo'. We throw away
-    # everything but the 'bearer_token'.
-    results, _ = qumulo.rest.auth.login(conninfo, None, username, password)
+    # Get the bearer token by passing through 'conninfo'.
+    results, _etag = qumulo.rest.auth.login(conninfo, None, username, password)
 
-    # Create a credentials object to use in the REST calls for alerts.
+    # Create a credentials object to use in the REST calls.
     creds = qumulo.lib.auth.Credentials.from_login_response(results)
 
     return RestInfo(conninfo, creds)
+
+
+def load_config(config_file: str) -> Dict[str, Any]:
+    if os.path.exists(config_file):
+        return load_json(config_file)
+    else:
+        sys.exit(f'Configuration file "{config_file}" does not exist.')
+
+
+def load_history(history_file: str) -> Dict[str, Any]:
+    """Load the history file, if available. Otherwise return a blank config."""
+    if os.path.exists(history_file):
+        return load_json(history_file)
+    else:
+        log.debug(f'History file "{history_file}" does not exist.')
+        return {'quotas': {}, 'capacity': {}, 'replication': {}}
+
+
+def save_history(history_file: str, history: Dict[str, Any]) -> None:
+    """Save the updated history file, if available."""
+
+    log.debug(f'Updating history file: {history_file}')
+    history_json = json.dumps(history)
+
+    with open(history_file, 'w') as f:
+        f.write(history_json)
+        f.close()
+
+
+def get_email_settings(config: Dict[str, Any], no_emails: bool) -> EmailSettings:
+    return EmailSettings(
+        config['email_settings']['sender_address'],
+        config['email_settings']['server_address'],
+        config['cluster_settings']['cluster_name'],
+        no_emails,
+    )
+
+
+def get_rest_credentials(config: Dict[str, Any]) -> RestInfo:
+    return cluster_login(
+        config['cluster_settings']['username'],
+        config['cluster_settings']['password'],
+        config['cluster_settings']['cluster_address'],
+        config['cluster_settings']['rest_port'],
+    )
 
 
 def send_or_log_mail(
@@ -121,229 +184,385 @@ def send_or_log_mail(
         session.quit()
 
 
-def humanize_bytes(num: float, suffix: str = 'B') -> str:
-    """
-    Convert bytes to a more human friendly size in base 10 to match the WebUI.
-    """
-    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
-        if abs(num) < 1000.0:
-            return '%3.1f%s%s' % (num, unit, suffix)
-        num /= 1000.0
-    return '%.1f%s%s' % (num, 'Y', suffix)
+#   ___  _   _  ___ _____  _    ____
+#  / _ \| | | |/ _ \_   _|/ \  / ___|
+# | | | | | | | | | || | / _ \ \___ \
+# | |_| | |_| | |_| || |/ ___ \ ___) |
+#  \__\_\\___/ \___/ |_/_/   \_\____/
 
 
-def check_quotas_for_capacity(
+def quota_capacity_check(
     email_settings: EmailSettings,
     rest_info: RestInfo,
-    quota_rules: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    options: argparse.Namespace,
 ) -> None:
     """
-    Check if any quotas have exeeded their configured thresholds. If so,
-    trigger an email alert. Terminology:
-
-        Usage = Percentage of quota used.
-        Used = Capacity of quota used.
-        Limit = Total capacity of quota.
+    Check if any quotas have exeeded their defined thresholds. If so, trigger
+    an alert check, which can email, log, or do nothing depeding on the
+    rules. If no rule is configured, the default rule will apply to undefined
+    quotas.
     """
-    qr = qumulo.rest
+    history = load_history(options.history_file)
+    log.info(f'Checking the quotas on {rest_info.conninfo.host}')
 
-    for quota in quota_rules:
-        log.info('Checking quota rule: {}'.format(quota['name']))
+    total_cap, _used_cap, _used_cap_pct = cluster_get_fs_usage(rest_info)
+    quotas = get_current_quotas(rest_info)
 
-        # Convert quota directory path to file system ID.
-        quota_id = qr.fs.get_file_attr(
-            rest_info.conninfo, rest_info.creds, quota['path']
-        )[0]['id']
+    # Process config and apply rules to quotas if defined, else apply default rules.
+    processed_quotas = process_quotas_and_rules(quotas, config)
 
-        # Use ID to get directory quota detail and status.
-        quota_details = qr.quota.get_quota_with_status(
-            rest_info.conninfo, rest_info.creds, quota_id
+    # Check which quotas are currently exceeding a rule's alert threshold.
+    alert_quotas = get_alerting_quotas(processed_quotas)
+
+    # For each alerting quota rule, compare with the history and determine if
+    # a log or email is necessary. Remove any quotas no longer alerting.
+    notify_quotas, history = process_quotas_with_history(alert_quotas, history)
+
+    for quota_path, rules in notify_quotas.items():
+        for rule_name, rule_details in rules.items():
+            log.info(
+                f'Quota "{quota_path}" exceeds threshold of '
+                f'{rule_details["alert_threshold"]} for rule: "{rule_name}"'
+            )
+            quota_send_alert(
+                email_settings, quota_path, rule_details, humanize_bytes(total_cap),
+            )
+
+    save_history(options.history_file, history)
+
+
+def get_current_quotas(rest_info: RestInfo) -> Dict[str, Any]:
+    """Get the status of all the quotas on the cluster."""
+    quotas = {}
+
+    responses = qumulo.rest.quota.get_all_quotas_with_status(
+        rest_info.conninfo, rest_info.creds
+    )
+
+    # Convert the PagingIterator into a dict with the quota path as key.
+    quotas = {
+        quota['path']: quota
+        for response in responses
+        for quota in response.data['quotas']
+    }
+
+    return quotas
+
+
+def process_quotas_and_rules(
+    quotas: Dict[str, Any], config: Dict[str, Any]
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Take a list of quotas and the configuration, sort the quotas by configured and
+    unconfigured. Apply the default configuration to quotas not defined in the config
+    file. Return a combined list of all paths with their respective capacities and
+    rules.
+    """
+    defined_rules = config['quota_rules']
+    undefined_rules = config['default_quota_rules']
+
+    defined_quotas = {}
+    undefined_quotas = {}
+
+    for quota in quotas:
+        if quota in defined_rules:
+            defined_quotas[quota] = {**quotas[quota], **defined_rules[quota]}
+        elif quota not in defined_rules:
+            undefined_quotas[quota] = {**quotas[quota], **undefined_rules}
+
+    processed_quotas = {**defined_quotas, **undefined_quotas}
+
+    return processed_quotas
+
+
+def get_alerting_quotas(quotas: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """
+    Compare all quota's current used capacity against each rule. Return the quotas
+    with the rules that would be in an alert state.
+    """
+
+    alert_quotas = {}
+
+    for path, quota in quotas.items():
+        quota_used = humanize_bytes(int(quota['capacity_usage']))
+        quota_limit = humanize_bytes(int(quota['limit']))
+        pct_used = round(
+            (float(quota['capacity_usage']) / float(quota['limit'])) * 100, 2
         )
 
-        # Get quota used percentage, rounding happens in email.
-        quota_used = quota_details[0]['capacity_usage']
-        quota_limit = quota_details[0]['limit']
-        if quota_limit == 0:
-            sys.exit('Quota "{}" has a limit of 0.'.format(quota['name']))
-        pct_used = (float(quota_used) / float(quota_limit)) * 100
+        alert_rules = {}
+        for r_name, rule in quota['rules'].items():
 
-        # Check used percent versus configured limits and record if exceeded.
-        send_alert = False
-        threshold_exceeded = 0.0
-        for threshold in quota['thresholds']:
-            if pct_used > threshold:
-                threshold_exceeded = threshold
-                send_alert = True
+            log.debug(f'Checking quota rule "{r_name}" on path "{path}".')
 
-        # After looping through all thresholds, email if exceeded.
-        if send_alert:
-            log.info('Usage exceeds threshold for rule: {}'.format(quota['name']))
-            quota_send_alert(
-                email_settings, rest_info, quota, quota_details, threshold_exceeded
-            )
+            # Find highest exceeded threshold per rule.
+            alert_threshold = 0
+
+            for threshold in rule['thresholds']:
+                if threshold == 0:
+                    log.warning(f'Quota rule {r_name} has a threshold of 0.')
+                if pct_used > threshold:
+                    alert_threshold = threshold
+
+            if alert_threshold > 0:
+                log.info(
+                    f'Quota "{path}" usage of {pct_used}% exceeds '
+                    f'configured threshold of {alert_threshold}%.'
+                )
+                alert_rules[r_name] = {
+                    **rule,
+                    'alert_threshold': alert_threshold,
+                    'pct_used': pct_used,
+                    'quota_used': quota_used,
+                    'quota_limit': quota_limit,
+                }
+
+        if alert_rules:
+            alert_quotas[path] = alert_rules
+
+    return alert_quotas
+
+
+def process_quotas_with_history(
+    alert_quotas: Dict[str, Dict[str, Any]], history: Dict[str, Any]
+) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]:
+    """Compare alerting quota rules with the quota rules in the history and update
+    the history if needed."""
+
+    notify_quotas = {}
+
+    # Check the history for any quotas we have previously alerted on.
+    for alert_quota, alert_rules in alert_quotas.items():
+
+        # Assume new quota, alert for all rules.
+        if alert_quota not in history['quotas']:
+            notify_quotas[alert_quota] = alert_rules
+            history['quotas'][alert_quota] = alert_rules
+            continue
+
+        # Existing quota, check all rules.
+        if alert_quota in history['quotas']:
+            if alert_quota not in notify_quotas:
+                notify_quotas[alert_quota] = {}
+            for rule_name, rule_info in alert_rules.items():
+
+                # Existing quota, new rule; alert.
+                if rule_name not in history['quotas'][alert_quota]:
+
+                    # Edge case where a rule could be removed and a second rule
+                    # added in between. Need to ensure that the alert_path exists
+                    # as a key.
+                    if alert_quota not in notify_quotas:
+                        notify_quotas[alert_quota] = {}
+
+                    notify_quotas[alert_quota][rule_name] = rule_info
+                    history['quotas'][alert_quota][rule_name] = rule_info
+                    continue
+
+                # Existing quota, new threshold exceeded; alert.
+                if rule_name in history['quotas'][alert_quota]:
+                    if (
+                        rule_info['alert_threshold']
+                        > history['quotas'][alert_quota][rule_name]['alert_threshold']
+                    ):
+                        notify_quotas[alert_quota][rule_name] = rule_info
+                        history['quotas'][alert_quota][rule_name] = rule_info
+                    else:
+                        history['quotas'][alert_quota][rule_name] = rule_info
+
+    # Clean up history for any quotas or rules no longer alerting.
+    quotas_to_remove = []
+    rules_to_remove = []
+
+    for expired_quota in history['quotas']:
+        if expired_quota not in alert_quotas:
+            quotas_to_remove.append(expired_quota)
+            continue
+        for expired_rule in history['quotas'][expired_quota]:
+            if expired_rule not in alert_quotas[expired_quota]:
+                rules_to_remove.append([expired_quota, expired_rule])
+
+    try:
+        for q in quotas_to_remove:
+            del history['quotas'][q]
+    except KeyError:
+        log.warning(f'Unable to remove quota on path {q} from the history.')
+
+    try:
+        for r in rules_to_remove:
+            del history['quotas'][r[0]][r[1]]
+    except KeyError:
+        log.warning(
+            f'Unable to remove quota rule {r[1]} on path {r[0]} from the history.'
+        )
+
+    return notify_quotas, history
 
 
 def quota_send_alert(
     email_settings: EmailSettings,
-    rest_info: RestInfo,
-    quota_rule: Dict[str, Any],
-    quota_details: List[Dict[str, str]],
-    threshold: float,
+    quota_path: str,
+    rule_details: Dict[str, Any],
+    total_cap: str,
 ) -> None:
-    """
-    Generate the Subject and Body for the soft quota alert. The terminology is
-    the same as in the WebUI:
+    """Generate the Subject and Body for the soft quota alert."""
 
-        Usage = Percentage of quota used.
-        Used = Capacity of quota used.
-        Limit = Total capacity of quota.
+    subject = f'{email_settings.cluster_name}: Soft quota alert on path {quota_path}'
 
-    Note that the body of the email is HTML and will accept typical tags such
-    as <br> and <strong>. Two <br> are needed to add 1 line of space.
-    """
-    quota_used = quota_details[0]['capacity_usage']
-    quota_limit = quota_details[0]['limit']
-    quota_path = quota_rule['path']
-    quota_pct_used = round((float(quota_used) / float(quota_limit)) * 100, 2)
+    body = f'The quota on directory path "{quota_path}" has exceeded the usage threshold of {rule_details["alert_threshold"]}%.<br><br>Current quota usage is {rule_details["quota_used"]} out of {rule_details["quota_limit"]}.  ({rule_details["pct_used"]}% full)'
 
-    # Generate humanized capacity numbers to send.
-    q_used = humanize_bytes(int(quota_used))
-    q_limit = humanize_bytes(int(quota_limit))
+    if rule_details['include_capacity']:
+        body += f'<br><br>Cluster total capacity: {total_cap}'
 
-    # Compose the email to send.
-    subject = '{}: Soft quota alert on path {}'.format(
-        email_settings.cluster_name, quota_path
-    )
-    body = """The quota '{0[name]} on directory path {0[path]} has exceeded it's usage \
-threshold of {threshold}%.
-Current usage is {used} out of {limit}. ({full}% full)""".format(
-        quota_rule, threshold=threshold, used=q_used, limit=q_limit, full=quota_pct_used
-    )
+    if rule_details['custom_msg']:
+        body += f'<br><br>{rule_details["custom_msg"]}'
 
-    if quota_rule['include_capacity']:
-        # Cluster Stats
-        cluster_stats = qumulo.rest.fs.read_fs_stats(
-            rest_info.conninfo, rest_info.creds
-        )
-        cluster_capacity = int(cluster_stats[0]['total_size_bytes'])
-        body += '\nCluster total capacity: {}'.format(humanize_bytes(cluster_capacity))
-    if quota_rule['custom_msg']:
-        body += '\n{}'.format(quota_rule['custom_msg'])
-
-    body = body.replace('\n', '<br><br>')
-
-    # Send the actual email.
     send_or_log_mail(
         email_settings.no_emails,
         email_settings.server,
         email_settings.sender,
-        quota_rule['mail_to'],
+        rule_details['mail_to'],
         subject,
         body,
     )
 
 
-def send_cluster_capacity_alerts(
-    cluster_pct_used: float,
-    capacity_alerts: List[Dict[str, Any]],
-    emailer: Callable[[float, str, List[str]], None],
-) -> None:
-    for capacity_alert in capacity_alerts:
-        send_alert = False
-        for threshold in capacity_alert['thresholds']:
-            if cluster_pct_used > threshold:
-                threshold_exceeded = threshold
-                send_alert = True
-
-        if send_alert:
-            log.info(
-                'Cluster usage {} exceeds threshold {}'.format(
-                    cluster_pct_used, threshold_exceeded
-                )
-            )
-
-            emailer(
-                threshold_exceeded,
-                capacity_alert['custom_msg'],
-                capacity_alert['mail_to'],
-            )
+#   ____    _    ____   _    ____ ___ _______   __
+#  / ___|  / \  |  _ \ / \  / ___|_ _|_   _\ \ / /
+# | |     / _ \ | |_) / _ \| |    | |  | |  \ V /
+# | |___ / ___ \|  __/ ___ \ |___ | |  | |   | |
+#  \____/_/   \_\_| /_/   \_\____|___| |_|   |_|
 
 
 def cluster_capacity_check(
     email_settings: EmailSettings,
     rest_info: RestInfo,
-    capacity_alerts: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    options: argparse.Namespace,
 ) -> None:
     """
     Check if the capacity of the cluster has exceeded a threshold. If so,
-    trigger an email alert.
+    trigger an email alert if we have not done so already.
     """
-    log.info('Checking cluster capacity')
+    log.info(f'Checking the cluster capacity for {rest_info.conninfo.host}')
+    history = load_history(options.history_file)
 
-    cluster_stats = qumulo.rest.fs.read_fs_stats(rest_info.conninfo, rest_info.creds)
-    cluster_capacity = int(cluster_stats[0]['total_size_bytes'])
-    cluster_used = int(cluster_stats[0]['total_size_bytes']) - int(
-        cluster_stats[0]['free_size_bytes']
+    total, used, used_pct = cluster_get_fs_usage(rest_info)
+
+    send_alert = False
+    for rule_name, rule_info in config['capacity_rules'].items():
+        send_alert, exceeded_threshold = cluster_capacity_process_rule(
+            rule_name, rule_info, used_pct, history, options
+        )
+
+        if send_alert:
+            cluster_capacity_send_alert(
+                rule_info, email_settings, total, used, used_pct, exceeded_threshold
+            )
+
+
+def cluster_get_fs_usage(rest_info: RestInfo) -> Tuple[int, int, float]:
+    fs_stats = qumulo.rest.fs.read_fs_stats(rest_info.conninfo, rest_info.creds)
+    total_capacity = int(fs_stats[0]['total_size_bytes'])
+    used_capacity = int(fs_stats[0]['total_size_bytes']) - int(
+        fs_stats[0]['free_size_bytes']
     )
-    cluster_pct_used = (float(cluster_used) / float(cluster_capacity)) * 100
+    used_capacity_pct = round((float(used_capacity) / float(total_capacity)) * 100, 2)
 
-    emailer = functools.partial(
-        cluster_capacity_send_alert,
-        email_settings,
-        cluster_capacity,
-        cluster_used,
-        round(cluster_pct_used, 2),
-    )
+    return total_capacity, used_capacity, used_capacity_pct
 
-    send_cluster_capacity_alerts(cluster_pct_used, capacity_alerts, emailer)
+
+def cluster_capacity_process_rule(
+    rule_name: str,
+    rule_info: Dict[str, Any],
+    used_pct: float,
+    history: Dict[str, Any],
+    options: argparse.Namespace,
+) -> Tuple[bool, int]:
+    """Find highest exceeded threshold and alert if needed. Save to history if
+    new or next threshold exceeded. Remove from history if thresholds not
+    exceeded."""
+    send_alert = False
+    exceeded_threshold = None
+
+    for threshold in rule_info['thresholds']:
+        if used_pct > threshold:
+            exceeded_threshold = threshold
+
+    # Determine if an alert is needed.
+    if exceeded_threshold:
+        if rule_name in history['capacity']:
+            if exceeded_threshold > history['capacity'][rule_name]['alert_threshold']:
+                history['capacity'][rule_name] = {'alert_threshold': exceeded_threshold}
+                send_alert = True
+        else:
+            history['capacity'][rule_name] = {'alert_threshold': exceeded_threshold}
+            send_alert = True
+
+    # Clean up the history as needed.
+    if not exceeded_threshold:
+        if rule_name in history['capacity']:
+            try:
+                del history['capacity'][rule_name]
+            except KeyError:
+                log.error(f'Unable to remove capacity rule {rule_name}.')
+
+    if send_alert:
+        log.info(f'Cluster usage of {used_pct} exceeds threshold {exceeded_threshold}.')
+
+    save_history(options.history_file, history)
+
+    return send_alert, exceeded_threshold
 
 
 def cluster_capacity_send_alert(
+    rule: Dict[str, Any],
     email_settings: EmailSettings,
-    capacity: float,
-    used: float,
-    percent: float,
-    threshold: float,
-    custom_msg: str,
-    recipients: List[str],
+    total: int,
+    used: int,
+    used_pct: float,
+    threshold: int,
 ) -> None:
-    """
-    Send an alert because the cluster's capacity has exceeded the threshold.
-    """
-    # Generate humanized capacity numbers to send.
-    c_capacity = humanize_bytes(int(capacity))
-    c_used = humanize_bytes(int(used))
+    """Craft and send a cluster capacity alert due to an exceeded threshold."""
+    human_total = humanize_bytes(int(total))
+    human_used = humanize_bytes(int(used))
 
-    # Compose the email to send.
-    subject = '{}: Cluster capacity alert. Usage has exceeded {}'.format(
-        email_settings.cluster_name, threshold
+    subject = f'{email_settings.cluster_name}: Cluster capacity alert. Usage has exceeded {threshold}'
+
+    body = (
+        f'The cluster "{email_settings.cluster_name}" has exceeded its usage'
+        f'threshold of {threshold}%. Current usage is {human_used} out of '
+        f'{human_total} ({used_pct}% full).'
     )
 
-    body = """The cluster '{}' has exceeded its usage threshold of {}%.
-Current usage is {} out of {} ({}% full).""".format(
-        email_settings.cluster_name, threshold, c_used, c_capacity, percent
-    )
-
-    if custom_msg:
-        body += '\n{}'.format(custom_msg)
+    if rule['custom_msg']:
+        body += '\n{}'.format(rule['custom_msg'])
 
     body = body.replace('\n', '<br><br>')
 
-    # Send the actual email.
     send_or_log_mail(
         email_settings.no_emails,
         email_settings.server,
         email_settings.sender,
-        recipients,
+        rule['mail_to'],
         subject,
         body,
     )
 
 
-def replication_check_status(
+#  ____  _____ ____  _     ___ ____    _  _____ ___ ___  _   _
+# |  _ \| ____|  _ \| |   |_ _/ ___|  / \|_   _|_ _/ _ \| \ | |
+# | |_) |  _| | |_) | |    | | |     / _ \ | |  | | | | |  \| |
+# |  _ <| |___|  __/| |___ | | |___ / ___ \| |  | | |_| | |\  |
+# |_| \_\_____|_|   |_____|___\____/_/   \_\_| |___\___/|_| \_|
+
+
+def replication_status_check(
     email_settings: EmailSettings,
     rest_info: RestInfo,
-    replication_rules: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    options: argparse.Namespace,
 ) -> None:
     """
     Check all source & target replication relationships for errors. Trigger an
@@ -351,7 +570,11 @@ def replication_check_status(
     """
     log.info('Checking replication relationships')
 
+    history = load_history(options.history_file)
+
+    err_relationships = None
     qr = qumulo.rest
+
     src_relationships = qr.replication.list_source_relationship_statuses(
         rest_info.conninfo, rest_info.creds
     )[0]
@@ -362,106 +585,161 @@ def replication_check_status(
     )[0]
     err_relationships += [r for r in tgt_relationships if r['error_from_last_job']]
 
+    for rule_name, rule_info in config['replication_rules'].items():
+        send_alert = False
+        send_alert = replication_process_rules(
+            rule_name, rule_info, err_relationships, history, options
+        )
+        if send_alert:
+            log.info('Errors found in replication relationships')
+            replication_send_alert(email_settings, rule_info, err_relationships)
+
+
+def replication_process_rules(
+    rule_name: str,
+    rule_info: Dict[str, Any],
+    err_relationships: List[str],
+    history: Dict[str, Any],
+    options: argparse.Namespace,
+) -> bool:
+    send_alert = False
+
+    # Determine if an alert is needed for all relationships, if an alert already
+    # exists, do nothing.
     if err_relationships:
-        log.info('Errors found in replication relationships')
-        replication_send_alert(email_settings, err_relationships, replication_rules)
+        if rule_name not in history['replication']:
+            history['replication'][rule_name] = rule_info
+            send_alert = True
+
+    # Clear out old alerts if there are no erroring relationships.
+    else:
+        if rule_name in history['replication']:
+            del history['replication'][rule_name]
+
+    if send_alert:
+        log.info(
+            f'Sending replication relationship error alert {rule_name} for {err_relationships}'
+        )
+
+    save_history(options.history_file, history)
+
+    return send_alert
 
 
 def replication_send_alert(
-    email_settings: EmailSettings,
-    relationships: List[Dict[str, Any]],
-    replication_rules: List[Dict[str, Any]],
+    email_settings: EmailSettings, rule_info: Dict[str, Any], err_relationships: Any,
 ) -> None:
+    """ Send an alert because a relationship has an error.
     """
-    Send an alert because a relationship has an error.
-    """
-    subject = '{}: Relationship error alert.'.format(email_settings.cluster_name)
+    subject = f'{email_settings.cluster_name}: Relationship error alert.'
     newline = '<br><br>'
 
     body = ''
     body += 'The following replication relationships have reported an error:'
     body += newline
-    for r in relationships:
+    for r in err_relationships:
         tmp_body = """Source cluster name: {0[source_cluster_name]}
 Source replication root path: {0[source_root_path]}
 Target cluster name: {0[target_cluster_name]}
 Target replication root path: {0[target_root_path]}
 Recovery point: {0[recovery_point]}
-Error from last replication job: {0[error_from_last_job]}""".format(
+Error from last replication job: {0[error_from_last_job]}\n""".format(
             r
         )
 
         tmp_body = tmp_body.replace('\n', newline)
         body += tmp_body
 
-    for rule in replication_rules:
-        msg_body = body + rule['custom_msg']
-        send_or_log_mail(
-            email_settings.no_emails,
-            email_settings.server,
-            email_settings.sender,
-            rule['mail_to'],
-            subject,
-            msg_body,
-        )
-
-
-def main() -> int:
-    """
-    Main function where the logic and config happens.
-    """
-    logging.basicConfig(
-        stream=sys.stdout,
-        level=logging.INFO,
-        format='%(asctime)s %(levelname)s: %(message)s',
+    msg_body = body + rule_info['custom_msg']
+    send_or_log_mail(
+        email_settings.no_emails,
+        email_settings.server,
+        email_settings.sender,
+        rule_info['mail_to'],
+        subject,
+        msg_body,
     )
 
+
+#  __  __    _    ___ _   _
+# |  \/  |  / \  |_ _| \ | |
+# | |\/| | / _ \  | ||  \| |
+# | |  | |/ ___ \ | || |\  |
+# |_|  |_/_/   \_\___|_| \_|
+
+
+def setup_logging(debug: bool) -> None:
+    if debug:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+
+    logging.basicConfig(
+        stream=sys.stdout, level=level, format='%(asctime)s %(levelname)s: %(message)s',
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description='This script will generate email alerts when run based \
                     on the configuration passed through in --config. This \
                     script requires the Qumulo API Tools which can be \
                     downloaded using pip or from the cluster itself.'
     )
+
     parser.add_argument(
-        '-c', '--config', required=True, help='Configuration file to be used.'
+        '-c',
+        '--config',
+        dest='config_file',
+        required=True,
+        help='Configuration file to be used.',
     )
+
+    parser.add_argument(
+        '-H',
+        '--history',
+        dest='history_file',
+        required=False,
+        default='history.json',
+        help='File used to store the alert history.',
+    )
+
     parser.add_argument(
         '--no-emails',
         action='store_true',
-        help='Do not send emails. Emails will be logged instead.',
+        help='Do not send emails; log them to stdout instead.',
     )
 
-    options = parser.parse_args()
-    config = options.config
-
-    # Load the config.json file into an object.
-    loaded_config = load_config(config)
-
-    # Email Details
-    email_settings = EmailSettings(
-        loaded_config['email_settings']['sender_address'],
-        loaded_config['email_settings']['server_address'],
-        loaded_config['cluster_settings']['cluster_name'],
-        options.no_emails,
+    parser.add_argument(
+        '--debug',
+        required=False,
+        default=False,
+        action='store_true',
+        help='Enable debug logging for the script.',
     )
 
-    # Cluster Config Details
-    username = loaded_config['cluster_settings']['username']
-    password = loaded_config['cluster_settings']['password']
-    cluster_addr = loaded_config['cluster_settings']['cluster_address']
-    port = loaded_config['cluster_settings']['rest_port']
+    return parser.parse_args(argv)
 
-    # Generate Connection Info & Credentials
-    rest_info = cluster_login(username, password, cluster_addr, port)
 
-    cluster_capacity_check(email_settings, rest_info, loaded_config['capacity_rules'])
-    check_quotas_for_capacity(email_settings, rest_info, loaded_config['quota_rules'])
-    replication_check_status(
-        email_settings, rest_info, loaded_config['replication_rules']
-    )
+def main(options: argparse.Namespace) -> int:
+
+    setup_logging(options.debug)
+
+    config = load_config(options.config_file)
+    email_settings = get_email_settings(config, options.no_emails)
+    rest_creds = get_rest_credentials(config)
+
+    cluster_checks = [
+        cluster_capacity_check,
+        quota_capacity_check,
+        replication_status_check,
+    ]
+
+    for cluster_check in cluster_checks:
+        cluster_check(email_settings, rest_creds, config, options)
 
     return 0
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    sys.exit(main(parse_args(sys.argv[1:])))

--- a/example_config.json
+++ b/example_config.json
@@ -1,61 +1,158 @@
 {
-    "email_settings":{
-        "server_address":"your-domain.com",
-        "sender_address":"cluster@your-domain.com"
+    "capacity_rules": {
+        "Administrators Rule": {
+            "custom_msg": "Cluster is almost full.",
+            "mail_to": [
+                "admins@company.com",
+                "storage@company.com"
+            ],
+            "thresholds": [
+                85,
+                90,
+                95
+            ]
+        },
+        "Storage Users Rule": {
+            "custom_msg": "A custom message for these users. For info, see https://some.site.company.com",
+            "mail_to": [
+                "department@company.com"
+            ],
+            "thresholds": [
+                60,
+                65,
+                70
+            ]
+        }
     },
-    "cluster_settings":{
-        "cluster_name":"cluster",
-        "cluster_address":"cluster.eng.your-domain.com",
-        "username":"admin",
-        "password":"admin",
-        "rest_port":8000
+    "cluster_settings": {
+        "cluster_address": "cluster1.company.com",
+        "cluster_name": "cluster1",
+        "password": "password",
+        "rest_port": 8000,
+        "username": "admin"
     },
-    "quota_rules":[
-            {
-                "name":"FriendlyQuotaName",
-                "path":"/exact/cluster/path/",
-                "thresholds":[ 80.0, 90.0, 95.0 ],
-                "mail_to":[ "admins@your-domain.com", "admins2@your-domain.com" ],
-                "include_capacity":true,
-                "custom_msg":"A custom message to be sent to the recipients."
+    "default_quota_rules": {
+        "rules": {
+            "Default Quota Rule - Critical": {
+                "custom_msg": "CRITICAL - A quota is almost full.",
+                "include_capacity": true,
+                "mail_to": [
+                    "admins@company.com",
+                    "storage@company.com"
+                ],
+                "name": "Quota",
+                "thresholds": [
+                    80,
+                    85,
+                    90
+                ]
             },
-            {
-                "name":"AnotherFriendlyQuota",
-                "path":"/another_path/",
-                "thresholds":[ 80.0, 90.0, 95.0 ],
-                "mail_to":[ "users@your-domain.com" ],
-                "include_capacity":false,
-                "custom_msg":"Please follow up with IT at 1-800-111-11111"
+            "Default Quota Rule - Error": {
+                "custom_msg": "ERROR - A quota has reached capacity.",
+                "include_capacity": true,
+                "mail_to": [
+                    "admins@company.com",
+                    "storage@company.com"
+                ],
+                "name": "Quota",
+                "thresholds": [
+                    60,
+                    70,
+                    75
+                ]
             },
-            {
-                "name":"Example - Marketing - Videos",
-                "path":"/marketing/videos/",
-                "thresholds":[ 80.0, 90.0, 95.0 ],
-                "mail_to":[ "dl_makerting_mgr@your-company.com"],
-                "include_capacity":false,
-                "custom_msg":"Your team is close to exceeding its quota. Please follow up with IT at 1-800-111-1111 for additional storage."
+            "Default Quota Rule - Warning": {
+                "custom_msg": "WARNING - A quota has is reaching capacity.",
+                "include_capacity": true,
+                "mail_to": [
+                    "admins@company.com",
+                    "storage@company.com"
+                ],
+                "name": "Quota",
+                "thresholds": [
+                    50,
+                    55,
+                    60
+                ]
             }
-    ],
-    "capacity_rules":[
-            {
-                "thresholds":[ 75.0, 80.0, 90.0, 95.0 ],
-                "mail_to":[ "admins@your-domain.com", "admins2@your-domain.com" ],
-                "custom_msg":"Warning! Please do something, cluster almost full."
-            },
-            {
-                "thresholds":[ 80.0, 90.0, 95.0 ],
-                "mail_to":[ "admins@your-domain.com", "admins2@your-domain.com" ],
-                "custom_msg":""
+        }
+    },
+    "email_settings": {
+        "sender_address": "cluster1@company.com",
+        "server_address": "mail.corp.company.com"
+    },
+    "quota_rules": {
+        "/marketing/videos/": {
+            "rules": {
+                "Alert Marketing Department": {
+                    "custom_msg": "A custom message to be sent to the recipients.",
+                    "include_capacity": false,
+                    "mail_to": [
+                        "dl_makerting_mgr@company.com"
+                    ],
+                    "thresholds": [
+                        80,
+                        90,
+                        95
+                    ]
+                }
             }
-    ],
-    "replication_rules":[
-            {
-                "mail_to":[ "admins@your-domain.com", "admins2@your-domain.com" ],
-                "custom_msg":"Replication gone wrong on this cluster."
-            },
-            {
-                "mail_to":[ "admins@your-domain.com", "admins2@your-domain.com" ],
-                "custom_msg":""
+        },
+        "/sample_path1/subpath/": {
+            "rules": {
+                "Alert Specific Users": {
+                    "custom_msg": "Please follow up with IT at 1-800-111-11111",
+                    "include_capacity": false,
+                    "mail_to": [
+                        "users@company.com"
+                    ],
+                    "thresholds": [
+                        80,
+                        90,
+                        95
+                    ]
+                }
             }
-    ]
+        },
+        "/sample_path2/subpath/subpath/": {
+            "Alert Team Leads": {
+                "custom_msg": "Message to be sent to the recipients for this rule.",
+                "include_capacity": true,
+                "mail_to": [
+                    "lead1@company.com",
+                    "lead2@company.com"
+                ],
+                "rule_name": "Alert Team Leads",
+                "thresholds": [
+                    70,
+                    75,
+                    80
+                ]
+            },
+            "rules": {
+                "Alert Administrators": {
+                    "custom_msg": "Message to be sent to the recipients for this rule.",
+                    "include_capacity": true,
+                    "mail_to": [
+                        "admin1@company.com",
+                        "admin2@company.com"
+                    ],
+                    "thresholds": [
+                        85,
+                        90,
+                        95
+                    ]
+                }
+            }
+        }
+    },
+    "replication_rules": {
+        "Replication Rule": {
+            "custom_msg": "Replication has an issue on this cluster.",
+            "mail_to": [
+                "admins@company.com",
+                "storage@company.com"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
The script has been updated with the end goal of alerting once per alert condition; regardless of how many times the script is run. This is done via storing historical alert conditions in a history file.